### PR TITLE
Update to reflect change from mvn to gradle

### DIFF
--- a/architecture/uaa.html.md
+++ b/architecture/uaa.html.md
@@ -256,7 +256,9 @@ $ ./gradlew run
 </pre>
 
 
-<!-- *** Note to Reviewers: Should this next section be included? Are the field values correct?  *** -->
+### Note to Reviewers: 
+
+Should this next section be included? Are the field values correct?  
 
 To bootstrap a microcloud type environment, you need an admin client; there is a database initializer component that inserts one.
 If the default profile is active (i.e. not `postgresql`), there is also a `cf` client so that the gem login works out of the box.
@@ -314,10 +316,12 @@ The profile names are double-barreled (e.g. `local-vcap` when the login server i
         GET /app
 
 
-<!-- *** Note to Reviewers: Should this next section be included, with a note that the login_server is in 
+### Question for Reviewers: 
+
+Should this next section be included, with a note that the login_server is in 
 	a different location now. Or should this just be a pointer to the README file for the login_server
 	rather than duplicate the content? Personally, I think a pointer is sufficient and better because
-	then the info does not have to be maintained in two different places *** --> 
+	then the info does not have to be maintained in two different places.
 
 
 ### <a id='login-application'></a>Login Application ###


### PR DESCRIPTION
The only changed file in this fork is architecture/uaa.html.md. Nearly all of the edits are updates to the instructions for building and running the UAA and the sample programs. The build is now Gradle based.

However, in reviewing the material covered in this document, I noticed that all, or nearly all of the content of this document is already covered in the documents in the actual UAA repository. Rather than maintain the information in two different places and be subject to future changes like this one from Maven to Gradle, I think a better approach would be to just have the document in docs-cloudfoundry-concepts/architecture/uaa be a pointer to the relevant docs in https://cloudfoundry/uaa (the README.md and the files in the docs directory). <a href="mailto:fhanik@pivotal.io">Filip Hanik</a>, one of the key contributors to the UAA agrees. 

I wasn't quite sure how to express that desire in a pull 
cbenson@pivotal.io
