### PR TITLE
Updated the link to NATS to point to NATS-io Github

### DIFF
--- a/architecture/messaging-nats.html.md.erb
+++ b/architecture/messaging-nats.html.md.erb
@@ -6,7 +6,7 @@ owner: Infrastructure
 
 <strong><%= modified_date %></strong>
 
-This information was adapted from the [NATS](https://github.com/derekcollison/nats) README. NATS is a lightweight publish-subscribe and distributed queueing messaging system written in Ruby.
+This information was adapted from the [NATS](https://github.com/nats-io/gnatsd) README. NATS is a lightweight publish-subscribe and distributed queueing messaging system written in Ruby.
 
 ## <a id='install'></a>Install NATS ##
 


### PR DESCRIPTION
The link that was there (https://github.com/derekcollison/nats) is a link to a deprecated personal repo, so was redirecting to Ruby NATS, not the NATS Server repo.. if you just want the Ruby repo and link to that, it's https://github.com/nats-io/ruby-nats/releases/tag/v0.7.1