### PR TITLE
corrected row header to clarify it's about assigning roles, not addin…

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -16,7 +16,7 @@
         <td>Space</td>
         <td>Space</td>
     </tr><tr>
-        <td>Add and edit users and roles</td>
+        <td>Assign user roles</td>
         <td>&check;</td>
         <td></td>
         <td></td>


### PR DESCRIPTION
…g (creating) new users

In OSS CF (i.e. no GUI, only cf CLI and CC API) only admins can create users. What Org Managers can do (depending on a feature flag, but I believe it's enabled by default), is assign roles to users, and remove roles from users. Org Managers can do that for users in their org; Space Managers can do that for users in their space.