### PR TITLE
Add bing-staging-security-group support

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -110,7 +110,7 @@ dependencies.
 
 You use different commands to apply an ASG to each of the four sets. For more information, see the [Procedures](#procedures) section of this topic.
 
-<p class="note"><strong>Note</strong>: To apply a staging ASG to apps within a space, you must use the CC API. The cf CLI <code>cf bind-security-group</code> command supports space-scoped running ASGs, but not space-scoped staging ASGs.</p>
+<p class="note"><strong>Note</strong>: The cf CLI <code>cf bind-security-group</code> command supports space-scoped running ASGs, and the <code>cf bind-staging-security-group</code> command supports space-scoped staging ASGs.</p>
 
 ### <a id='creating-groups'></a>The Structure and Attributes of ASGs ##
 


### PR DESCRIPTION
The "Understanding Application Security Groups" section of the docs has a note that states:
> To apply a staging ASG to apps within a space, you must use the CC API. The cf CLI `cf bind-security-group` command supports space-scoped running ASGs, but not space-scoped staging ASGs.

The CF CLI installed via brew (`cf version 6.26.0+9c9a261fd.2017-04-06`) contains a `bind-staging-security-group` command, so this change just reflects this in the docs.