### PR TITLE
removed minimum requirement of old cf CLI

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -20,8 +20,6 @@ owner: Security
 
 <strong><%= modified_date %></strong>
 
-_This page assumes you are using cf CLI v6.4 or later._
-
 ## <a id='introduction'></a>Introduction ##
 
 This topic provides an overview of Application Security Groups (ASGs), and describes how to manage and administer them. Many of the steps below require the [Cloud Foundry Command Line Interface](../cf-cli/install-go-cli.html) (cf CLI) tool. 


### PR DESCRIPTION
cf CLI 6.4 was released almost 3 years ago. This note has become clutter.