### PR TITLE
Add reference to grootfs

### DIFF
--- a/architecture/garden.html.md.erb
+++ b/architecture/garden.html.md.erb
@@ -24,7 +24,7 @@ For more information, see the [Garden repository](https://github.com/cloudfoundr
 
 ##<a id='garden-runc'></a>Garden-runC
 
-Cloud Foundry currently uses the [Garden-runC](https://github.com/cloudfoundry-incubator/garden-runc-release) backend, a Linux-specific implementation of the Garden interface using the [Open Container Interface](https://github.com/opencontainers/runtime-spec) (OCI) standard. Previous versions of Cloud Foundry used the [Garden-Linux](https://github.com/cloudfoundry-attic/garden-linux) backend. 
+Cloud Foundry currently uses the [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) backend, a Linux-specific implementation of the Garden interface using the [Open Container Interface](https://github.com/opencontainers/runtime-spec) (OCI) standard. Previous versions of Cloud Foundry used the [Garden-Linux](https://github.com/cloudfoundry-attic/garden-linux) backend.
 
 <%= vars.garden_runc %>
 
@@ -36,4 +36,22 @@ by default for all unprivileged containers
 * Seccomp whitelisting restricts the set of system calls a container can access, reducing the risk of container breakout
 * Allows pluggable networking and rootfs management
 
-For more information, see the [Garden-runC repository](https://github.com/cloudfoundry-incubator/garden-runc-release) on GitHub.
+For more information, see the [Garden-runC repository](https://github.com/cloudfoundry/garden-runc-release) on GitHub.
+
+##<a id='garden-rootfs'></a>Garden RootFS (Grootfs)
+
+Garden has a plugin interface for managing containers filesystems,
+CloudFoundry uses the [Grootfs](https://github.com/cloudfoundry/grootfs) plugin for this task.
+Grootfs is a Linux-specific implementation of the Garden volume plugin interface.
+
+Grootfs is responsible for the following actions:
+
+- Create containers filesystems based on buildpacks and droplets
+- Create containers filesystems based on remote docker images
+- Authenticate with remote registries when using remote images
+- Properly map UID/GID for all the files inside the image
+- Execute garbage collection to remove unused volumes
+- Apply per container disk quotas
+- Provide per container disk usage stats
+
+For more information, see the [Grootfs repository](https://github.com/cloudfoundry/grootfs) on GitHub.

--- a/container-security.html.md.erb
+++ b/container-security.html.md.erb
@@ -17,7 +17,11 @@ Each instance of an app deployed to CF runs within its own self-contained enviro
 
 CF achieves container isolation by namespacing kernel resources that would otherwise be shared. The intended level of isolation is set to prevent multiple containers that are present on the same host from detecting each other. Every container includes a private root filesystem, which includes a Process ID (PID), namespace, network namespace, and mount namespace.
 
-CF creates the container filesystem by stacking a read-only base filesystem and a container-specific read-write filesystem, commonly known as an overlay filesystem. The read-only filesystem contains the minimal set of operating system packages and Garden-specific modifications common to all containers. Containers can share the same read-only base filesystem because all writes are applied to the read-write filesystem. The read-write filesystem is unique to each container and is created by formatting a large sparse file of a fixed size. This fixed size prevents the read-write filesystem from overflowing into unallocated space.
+CF uses the [Garden Rootfs](./architecture/garden.html#garden-rootfs) (Grootfs) tool to create the container filesystem by stacking a read-only base filesystem and a container-specific read-write layer, specifically by using OverlayFS.
+The read-only filesystem contains the minimal set of operating system packages and Garden-specific modifications common to all containers.
+Containers can share the same read-only base filesystem because all writes are applied to the read-write layer.
+The read-write layer is unique to each container and has it's size limited by XFS project quotas.
+This quota prevents the read-write layer from overflowing into unallocated space.
 
 Resource control is managed using Linux control groups ([cgroups](https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt)). Associating each container with its own cgroup or job object limits the amount of memory that the container may use. Linux cgroups also require the container to use a fair share of CPU compared to the relative CPU share of other containers. 
 
@@ -91,7 +95,7 @@ CF mitigates against container breakout and denial of service attacks in the fol
     * Egress whitelist rules are applied to these interfaces according to Application Security Groups (ASGs) configured by the administrator.
     * First-packet logging rules may also be enabled on TCP whitelist rules.
     * DNAT rules are established on the host to enable traffic ingress from the host interface to whitelisted ports on the container-side interface.
-* CF applies disk quotas by confining container-specific filesystem layers to loop devices with the specified disk-quota capacity.
+* CF applies disk quotas using container-specific XFS quotas with the specified disk-quota capacity.
 * CF applies a total memory usage quota through the memory cgroup and destroys the container if the memory usage exceeds the quota.
 * CF applies a fair-use limit to CPU usage for processes inside the container through the `cpu.shares` control group.
 * CF limits access to devices using cgroups but explicitly whitelists the following safe device nodes:


### PR DESCRIPTION
Add information about Grootfs to the garden architecture page.
Update container security with how Grootfs handles the filesystem
creation and its specific security implementation details.

(Also updates some links to the garden-runc-release repository, which is no longer in the cloudfoundry-incubator organization)

[#150266114 #150265783]