### PR TITLE
Add Org User status to roles description and table

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -170,6 +170,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+	<td>&check;</td>
     </tr><tr>
         <td>Edit spaces</td>
         <td>&check;</td>

--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -7,6 +7,7 @@
         <th>Org Manager</th>
         <th>Org Auditor</th>
         <th>Org Billing Manager</th>
+        <th>Org User</th>
         <th>Space Manager</th>
         <th>Space Developer</th>
         <th>Space Auditor</th>
@@ -19,6 +20,7 @@
         <td>Org</td>
         <td>Org</td>
         <td>Org</td>
+	<td>Org</td>
         <td>Space</td>
         <td>Space</td>
         <td>Space</td>
@@ -30,6 +32,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>
         <td></td> 
@@ -44,6 +47,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+	<td>&check;</td>
     </tr><tr>
         <td>Create and assign org quota plans</td>
         <td>&check;</td>
@@ -55,6 +59,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
         <td>View org quota plans</td>
         <td>&check;</td>
@@ -66,6 +71,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+	<td>&check;</td>
     </tr><tr>
         <td>Create orgs</td>
         <td>&check;</td>
@@ -76,7 +82,8 @@
         <td><sup>&#42;</sup></td>
         <td><sup>&#42;</sup></td>
         <td><sup>&#42;</sup></td>
-        <td><sup>&#42;</sup></td>      
+        <td><sup>&#42;</sup></td> 
+	<td><sup>&#42;</sup></td> 
     </tr>
     <tr>
         <td>View all orgs</td>
@@ -89,6 +96,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
         <td>View orgs where user is member</td>
         <td>&check;<sup>&#42;</sup><sup>&#42;</sup></td>
@@ -100,6 +108,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+	<td>&check;</td>
     </tr><tr>
         <td>Edit, rename, and delete orgs</td>
         <td>&check;</td>
@@ -111,6 +120,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
         <td>Suspend or activate an org</td>
         <td>&check;</td>
@@ -122,6 +132,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr>
     <tr>
         <td>Create and assign space quota plans</td>
@@ -134,6 +145,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr>
     <tr>
         <td>Create spaces</td>
@@ -146,6 +158,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
         <td>View spaces</td>
         <td>&check;</td>
@@ -165,6 +178,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>     
 	<td></td>
@@ -176,6 +190,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+	<td></td>
         <td></td>  
         <td></td>
 	<td></td>
@@ -187,6 +202,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>
         <td></td>
@@ -198,6 +214,7 @@
         <td></td>
         <td></td>
         <td>&check;</td>
+	<td></td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
@@ -212,6 +229,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
         <td>Deploy, run, and manage applications</td>
         <td>&check;</td>
@@ -220,6 +238,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
         <td></td>
         <td>&check;</td>
         <td></td>     
@@ -232,6 +251,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>        
     </tr><tr>
@@ -243,6 +263,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>        
     </tr><tr>
@@ -254,6 +275,7 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
         <td>&check;</td>
         <td></td>
      </tr><tr>
@@ -266,10 +288,12 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
         <td></td>
     </tr><tr>
 	    <td>Create, update, and delete an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
 	    <td>&check;</td>
+	    <td></td>
 	    <td></td>
 	    <td></td>
 	    <td></td>
@@ -288,6 +312,7 @@
         <td>&check;&#135;</td>
         <td>&check;&#135;</td>
         <td>&check;&#135;</td>
+	<td>&check;&#135;</td>
         <td>&check;&#135;</td>
     </tr><tr>
         <td>Entitle or revoke an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
@@ -300,10 +325,12 @@
         <td></td>
         <td></td>
         <td></td>
+	<td></td>
     </tr><tr>
 		<td>List all Orgs entitled to an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
 		<td>&check;</td>
 		<td>&check;</td>
+		<td>&check;&#135;</td>
 		<td>&check;&#135;</td>
 		<td>&check;&#135;</td>
 		<td>&check;&#135;</td>
@@ -322,12 +349,14 @@
 		<td></td>
 		<td></td>
 		<td></td>
+		<td></td>
     </tr><tr>
 		<td>List and manage <a href="../adminguide/isolation-segments.html">Isolation Segments</a> for spaces</td>
 		<td>&check;</td>
 		<td></td>
 		<td></td>
 		<td>&check;</td>
+		<td></td>
 		<td></td>
 		<td></td>
 		<td></td>
@@ -341,6 +370,7 @@
 		<td>&check;</td>
 		<td></td>
 		<td></td>
+		<td></td>
 		<td>&check;</td>
 		<td>&check;</td>
 		<td>&check;</td>
@@ -352,6 +382,7 @@
 		<td>&check;</td>
 		<td></td>
 		<td></td>
+		<td></td>
 		<td>&check;</td>
 		<td>&check;</td>
 		<td>&check;</td>
@@ -359,6 +390,7 @@
 		<td>List application and service usage events</td>
 		<td>&check;</td>
 		<td>&check;</td>
+		<td></td>
 		<td></td>
 		<td></td>
 		<td></td>

--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -167,10 +167,10 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+        <td></td>
         <td>&check;</td>
         <td>&check;</td>
-        <td>&check;</td>
-	<td>&check;</td>
+	    <td>&check;</td>
     </tr><tr>
         <td>Edit spaces</td>
         <td>&check;</td>

--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -20,7 +20,7 @@
         <td>Org</td>
         <td>Org</td>
         <td>Org</td>
-	<td>Org</td>
+        <td>Org</td>
         <td>Space</td>
         <td>Space</td>
         <td>Space</td>
@@ -32,7 +32,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>
         <td></td> 
@@ -47,7 +47,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
-	<td>&check;</td>
+        <td>&check;</td>
     </tr><tr>
         <td>Create and assign org quota plans</td>
         <td>&check;</td>
@@ -59,7 +59,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
         <td>View org quota plans</td>
         <td>&check;</td>
@@ -71,7 +71,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
-	<td>&check;</td>
+        <td>&check;</td>
     </tr><tr>
         <td>Create orgs</td>
         <td>&check;</td>
@@ -83,7 +83,7 @@
         <td><sup>&#42;</sup></td>
         <td><sup>&#42;</sup></td>
         <td><sup>&#42;</sup></td> 
-	<td><sup>&#42;</sup></td> 
+        <td><sup>&#42;</sup></td> 
     </tr>
     <tr>
         <td>View all orgs</td>
@@ -96,7 +96,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
         <td>View orgs where user is member</td>
         <td>&check;<sup>&#42;</sup><sup>&#42;</sup></td>
@@ -108,7 +108,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
-	<td>&check;</td>
+        <td>&check;</td>
     </tr><tr>
         <td>Edit, rename, and delete orgs</td>
         <td>&check;</td>
@@ -120,7 +120,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
         <td>Suspend or activate an org</td>
         <td>&check;</td>
@@ -132,7 +132,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr>
     <tr>
         <td>Create and assign space quota plans</td>
@@ -145,7 +145,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr>
     <tr>
         <td>Create spaces</td>
@@ -158,7 +158,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
         <td>View spaces</td>
         <td>&check;</td>
@@ -178,7 +178,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>     
 	<td></td>
@@ -190,7 +190,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td></td>  
         <td></td>
 	<td></td>
@@ -202,7 +202,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>
         <td></td>
@@ -229,7 +229,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
         <td>Deploy, run, and manage applications</td>
         <td>&check;</td>
@@ -238,7 +238,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td></td>
         <td>&check;</td>
         <td></td>     
@@ -251,7 +251,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>        
     </tr><tr>
@@ -263,7 +263,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>        
     </tr><tr>
@@ -275,7 +275,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td>&check;</td>
         <td></td>
      </tr><tr>
@@ -288,7 +288,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
         <td></td>
     </tr><tr>
 	    <td>Create, update, and delete an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
@@ -312,7 +312,7 @@
         <td>&check;&#135;</td>
         <td>&check;&#135;</td>
         <td>&check;&#135;</td>
-	<td>&check;&#135;</td>
+        <td>&check;&#135;</td>
         <td>&check;&#135;</td>
     </tr><tr>
         <td>Entitle or revoke an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
@@ -325,7 +325,7 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
     </tr><tr>
 		<td>List all Orgs entitled to an <a href="../adminguide/isolation-segments.html">Isolation Segment</a></td>
 		<td>&check;</td>

--- a/_suspended_org_roles_table.html.md.erb
+++ b/_suspended_org_roles_table.html.md.erb
@@ -166,7 +166,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-        <td>&check;</td>
+        <td></td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>

--- a/_suspended_org_roles_table.html.md.erb
+++ b/_suspended_org_roles_table.html.md.erb
@@ -7,11 +7,13 @@
         <th>Org Manager</th>
         <th>Org Auditor</th>
         <th>Org Billing Manager</th>
+        <th>Org User</th>
         <th>Space Manager</th>
         <th>Space Developer</th>
         <th>Space Auditor</th>      
     </tr><tr>
         <td>Scope of operation</td> 
+        <td>Org</td>
         <td>Org</td>
         <td>Org</td>
         <td>Org</td>
@@ -32,8 +34,10 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>View users and roles</td>
+        <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
@@ -54,8 +58,10 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>View org quota plans</td>
+        <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
@@ -76,11 +82,13 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>View all orgs</td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -99,6 +107,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+        <td>&check;</td>
     </tr><tr>
         <td>Edit, rename, and delete orgs</td>
         <td>&check;</td>
@@ -110,9 +119,11 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>Suspend or activate an org</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -133,10 +144,12 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr>
     <tr>
         <td>Create spaces</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -156,6 +169,7 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
+        <td>&check;</td>
     </tr><tr>
         <td>Edit spaces</td>
         <td>&check;</td>
@@ -166,10 +180,12 @@
         <td></td>
         <td></td>
         <td></td>
-	<td></td>
+        <td></td>
+	    <td></td>
     </tr><tr>
         <td>Delete spaces</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -189,6 +205,7 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>View the status, number of instances, service bindings, and resource use of applications</td>
         <td>&check;</td>
@@ -197,12 +214,14 @@
         <td>&check;</td>
         <td></td>
         <td></td>
+        <td></td>
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
     </tr><tr>
         <td>Add private domains<sup>&dagger;</sup></td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -222,9 +241,11 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>Instantiate and bind services to applications</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -244,9 +265,11 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
     </tr><tr>
         <td>Rename applications</td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>
@@ -259,6 +282,7 @@
        <tr>
         <td>Create and manage <a href="../concepts/asg.html">Application Security Groups</a></td>
         <td>&check;</td>
+        <td></td>
         <td></td>
         <td></td>
         <td></td>

--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -55,6 +55,8 @@ information.
 <%= vars.billing_manager_role %>
 <%= vars.billing_manager_role_note %>
 
+* **Org Users** can view the list of other org users and their roles. When an Org Manager gives a person an Org or Space role, that person automatically receives Org User status in that Org.
+
 * **Space Managers** are managers or other users who administer a space within an org.
 
 * **Space Developers** are application developers or other users who manage 


### PR DESCRIPTION
In order for my end-users in our regulated environment to have confidence that they are managing access to their orgs appropriately according to their access control requirements, they need to understand CF org user management in depth, including hidden/implied roles.

This is a proposal for documenting Org User status, following up on my comment at https://github.com/cloudfoundry/cli/issues/781#issuecomment-311832690 and [this discussion in #cf-docs in the Cloud Foundry Slack](https://cloudfoundry.slack.com/archives/C03B0T0D5/p1498687757249593). I figure an illustration of what might be helpful to us can be helpful. :)

This is a best guess at what the documentation should look like - I haven't verified all of the checkboxes here, and I haven't tried running this locally to check for formatting/display errors. I verified that if I have org user status (but no other roles) on an org, I can "View users and roles".