### PR TITLE
Use valid ICMP type/code pair in the ASG example

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -204,7 +204,7 @@ To create an ASG, perform the following steps:
         "protocol": "icmp",
         "destination": "0.0.0.0/0",
         "type": 0,
-        "code": 1
+        "code": 0
       },
       {
         "protocol": "tcp",


### PR DESCRIPTION
According to https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml, the pair of type 0 and code 1 is invalid.