### PR TITLE
Fix incorrectly documented permissions

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -212,9 +212,9 @@
         <td>&check;</td>
         <td>&check;</td>
         <td>&check;</td>
-        <td></td>
-        <td></td>
         <td>&check;</td>
+        <td></td>
+        <td></td>
 	<td></td>
         <td>&check;</td>
         <td>&check;</td>


### PR DESCRIPTION
This change fixes the permissions table to show that OrgManager has the
ability to 'View the status, number of instances, service bindings, and
resource use of applications', and OrgBillingManager does not.

We've verified on the latest Cloud Foundry version (cf deployment
v1.14.0) that this is correct.

Thanks,
Niki and @jenspinney