### PR TITLE
Small fix in sentence

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -24,7 +24,7 @@ ASGs apply to both buildpack-based and Docker-based apps and tasks.
 Administrators can define a `staging` ASG for app and task staging, and a `running` ASG for app and task runtime.
 
 When apps or tasks begin staging, they require traffic rules permissive enough to allow them to pull resources from the network.
-A running app or task no longer needs to pull traffic rules can be more restrictive and secure.
+A running app or task no longer needs this so traffic rules can be more restrictive and secure.
 To distinguish between these two security requirements, administrators can define a `staging` ASG for app and task staging with more permissive rules, and a `running` ASG for app and task runtime with less permissive rules.
 
 ### Platform-Wide and Space-Scoped ASGs


### PR DESCRIPTION
Changed 'running app or task no longer needs to pull traffic rules can be more restrictive and secure' into 'running app or task no longer needs this so traffic rules can be more restrictive and secure'