### PR TITLE
Update statement about spaces within an org

### DIFF
--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -30,7 +30,7 @@ Before you assign a space role to a user, you must assign an org role to the use
 ## <a id='spaces'></a>Spaces ##
 
 Every application and service is scoped to a space.
-Each org contains at least one space.
+An org can contain multiple spaces.
 A space provides users with access to a shared location for application
 development, deployment, and maintenance.
 Each space role applies only to a particular space.


### PR DESCRIPTION
An org can have zero spaces, so it's not correct to say that an org contains at least one space.  We have maintained the emphasis that an org can contain many spaces, but without being factually inaccurate.

Paired with @blgm