### PR TITLE
Correction that org managers can rename orgs

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -114,7 +114,7 @@
         <td>&check;</td>
         <td></td>
         <td></td>
-        <td></td>
+        <td>&check;&#8258;</td>
         <td></td>
         <td></td>
         <td></td>
@@ -409,3 +409,5 @@
 <sup>&dagger;</sup>Unless disabled by [feature flags](../adminguide/listing-feature-flags.html).
 
 <sup>&#135;</sup>Applies only to orgs they belong to.
+
+<sup>&#8258;</sup>Org Managers can rename their orgs and edit some fields; they cannot delete orgs.


### PR DESCRIPTION
Implements Tracker story: [#157755345][pt]

Story details say to wait to merge until CAPI PM @zrob can verifies the change.

[pt]: https://www.pivotaltracker.com/story/show/157755345