### PR TITLE
Update Zipkin header docs to reflect actual behaviour

### DIFF
--- a/http-routing.html.md.erb
+++ b/http-routing.html.md.erb
@@ -29,7 +29,7 @@ Zipkin is a tracing system that enables app developers to troubleshoot failures 
 <%= vars.zipkin_enable_link %>
 
 * If the `X-B3-TraceId` and `X-B3-SpanId` HTTP headers are not present in the request, the Gorouter generates values for these and inserts the headers into the request forwarded to an application. These values are also found in the Gorouter access log message for the request: `x_b3_traceid` and `x_b3_spanid`.
-* If both `X-B3-TraceId` and `X-B3-SpanId` HTTP headers are present in the request, the Gorouter forwards the same value for `X-B3-TraceId`, generates a new value for `X-B3-SpanId`, and adds the `X-B3-ParentSpan` header, and sets to the value of the span id in the request. In addition to these trace and span ids, the Gorouter access log message for the request includes `x_b3_parentspanid`.
+* If the `X-B3-TraceId` and `X-B3-SpanId` HTTP headers are present in the request, the Gorouter forwards them unmodified. In addition to these trace and span ids, the Gorouter access log message for the request includes `x_b3_parentspanid`.
 
 Developers can then add Zipkin trace IDs to their application logging in order to trace app requests and responses in Cloud Foundry.
 


### PR DESCRIPTION
As discussed in https://github.com/cloudfoundry/routing-release/issues/110, the current docs don't match the actual behaviour of gorouter. It doesn't perform the promotion for these headers any more, and instead passes them through unmodified.