### PR TITLE
Dedupe "Active Org roles" HTML entity id

### DIFF
--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -65,7 +65,7 @@ applications and services in a space.
 
 * **Space Auditors** view but cannot edit the space.
 
-### <a id='roles'></a>Roles and Permissions for Active Orgs ###
+### <a id='activeroles'></a>Roles and Permissions for Active Orgs ###
 
 The following table describes the permissions for various <%= vars.product_name %> roles.
 


### PR DESCRIPTION
The `roles` id is already used by the "Roles and Permissions" section.

Having duplicate IDs breaks clicks from the page's TOC. This fixes that, so all TOC clicks go to the correct place on the page.

Existing/external links to this id were only ever leading to the first use of the id, so nothing should change as a result.