### PR TITLE
Mention bandwidth rate limits for app containers

### DIFF
--- a/container-security.html.md.erb
+++ b/container-security.html.md.erb
@@ -168,6 +168,7 @@ CF mitigates against container breakout and denial of service attacks in the fol
 * CF applies disk quotas using container-specific XFS quotas with the specified disk-quota capacity.
 * CF applies a total memory usage quota through the memory cgroup and destroys the container if the memory usage exceeds the quota.
 * CF applies a fair-use limit to CPU usage for processes inside the container through the `cpu.shares` control group.
+* CF allows administrators to rate limit the maximum bandwidth consumed by single application containers, configuring `rate` and `burst` properties on the `silk-cni` job.
 * CF limits access to devices using cgroups but explicitly whitelists the following safe device nodes:
 	* `/dev/full`
 	* `/dev/fuse`


### PR DESCRIPTION
Hello,

it was very hard to find that is possible to limit bandwidth on application container level, therefore I propose to include this parameter on the documentation. 

Mention the configuration parameters present here https://github.com/cloudfoundry/silk-release/blob/92398d2fa7635479cec83b9d7046e5071c132806/jobs/silk-cni/spec#L38-L44

Best,
Michael