### PR TITLE
Fix wording of the description "Allow http and https traffic from ZoneA"

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -203,7 +203,7 @@ To create an ASG, perform the following steps:
         "destination": "10.0.11.0/24",
         "ports": "80,443",
         "log": true,
-        "description": "Allow http and https traffic from ZoneA"
+        "description": "Allow http and https traffic to ZoneA"
       }
     ]
     </pre>


### PR DESCRIPTION
the rule is egress rule, therefore the description should be  "Allow http and https traffic to ZoneA"