### PR TITLE
Update Java version requirements in quick start

### DIFF
--- a/architecture/uaa.html.md.erb
+++ b/architecture/uaa.html.md.erb
@@ -19,6 +19,9 @@ You can deploy the UAA locally or to Cloud Foundry.
 * [Deploy UAA Locally](#local)
 * [Deploy UAA to Cloud Foundry](#cf)
 
+### Requirements
+* Java 8
+
 ### <a id='local'></a>Deploy UAA Locally ###
 
 Follow the instructions below to deploy and run the UAA locally.


### PR DESCRIPTION
I ended up trying to make things work with Java 12 yesterday, only to find this requirement mentioned in the README ([034d0be](https://github.com/cloudfoundry/uaa/commit/034d0befd6821d4c167db45de93bf88f482e09a3)).