### PR TITLE
Update contribute.html.md.erb

### DIFF
--- a/contribute.html.md.erb
+++ b/contribute.html.md.erb
@@ -32,29 +32,16 @@ If you have identified a problem with the docs and know the required content cha
 
 The CF docs team typically accepts PRs within a day, but may need to ask follow-up questions.
 
-Before your PRs can be accepted, you must have a [signed Contributor License Agreement](#sign-cla) (CLA) on file.
+Before your PRs can be accepted, you must have a signed Contributor License Agreement (CLA) on file. If you do not, you will be prompted to sign this once you've opened your first PR.  
 
 To submit a pull request, follow these steps:
 
-1. **Prerequisite**: [Sign the CLA](#sign-cla) if you have not already done so.
 1. Navigate to the topic that you want to modify.
 1. To locate the GitHub source file that contains the content for the topic, scroll to the bottom of the page and click **Create a pull request or raise an issue on the source for this page in GitHub.**
 1. Click the pencil icon in the upper right to edit the file in GitHub.
 1. Make your desired changes.
 1. Under **Commit changes** at the bottom of the page, enter a description of your change and click **Propose file change**.
 1. Click **Create pull request**.
-
-#### <a id='sign-cla'></a> Sign and Publicize the CLA
-
-Before your Github pull request can be accepted, you must sign the Contributor License Agreement (CLA) as an individual or publicize your membership with an organization that has signed the CLA. To do this, perform the following steps:
-
-1. Complete and sign the appropriate CLA, either [individual](https://www.cloudfoundry.org/wp-content/uploads/2017/01/CFF_Individual_CLA.pdf) or [corporate](https://www.cloudfoundry.org/wp-content/uploads/2017/01/CFF_Corporate_CLA.pdf).
-1. Send a scan of the CLA to contributors@cloudfoundry.org, as instructed in the CLA. When sending the individual CLA, provide your GitHub username. When sending the corporate CLA, provide a list of GitHub usernames that can make pull requests on behalf of your organization.
-1. [Publicize](https://help.github.com/articles/publicizing-or-hiding-organization-membership/) your membership in the appropriate GitHub org.
-
-If you do not have a CLA on file with the <%= vars.product_short %> Foundation, the `cfdreddbot` notifies you after you submit the pull request. 
-
-If you receive the `cfdreddbot` notification, but are confident that you are already covered under a corporate or organizational CLA, then verify that you have [publicized](https://help.github.com/articles/publicizing-or-hiding-organization-membership/) your membership in an appropriate GitHub org.
 
 ###<a id='issue'></a> Raise a Github Issue
 


### PR DESCRIPTION
Cloud Foundry recently moved over to a new CLA tool, and retired the Dreddbot. Contributors are now prompted by the [EasyCLA](https://github.com/communitybridge/easycla) tool to sign a CLA when they put in their first pull request. This PR updates the docs to reflect those changes, removing some inaccuracies/redundancies.  

Please let me know if you have any questions, or would like any tweaks to this PR.  Happy New Year!