### PR TITLE
add gorouter time to gorouter access log docs

### DIFF
--- a/architecture/router.html.md.erb
+++ b/architecture/router.html.md.erb
@@ -193,10 +193,15 @@ This section section provides a sample Gorouter log message and and explanation 
 
 Access logs provide information for the following fields when receiving a request:
 
-`<Request Host> - [<Start Date>] "<Request Method> <Request URL> <Request Protocol>" <Status Code> <Bytes Received> <Bytes Sent> "<Referer>" "<User-Agent>" <Remote Address> <Backend Address> x_forwarded_for:"<X-Forwarded-For>" x_forwarded_proto:"<X-Forwarded-Proto>" vcap_request_id:<X-Vcap-Request-ID> response_time:<Response Time> app_id:<Application ID> app_index:<Application Index> <Extra Headers>`
+`<Request Host> - [<Start Date>] "<Request Method> <Request URL> <Request Protocol>" <Status Code> <Bytes Received> <Bytes Sent> "<Referer>" "<User-Agent>" <Remote Address> <Backend Address> x_forwarded_for:"<X-Forwarded-For>" x_forwarded_proto:"<X-Forwarded-Proto>" vcap_request_id:<X-Vcap-Request-ID> response_time:<Response Time> gorouter_time:<GoRouter Time> app_id:<Application ID> app_index:<Application Index> <Extra Headers>`
 
-The following are optional fields: <code>Status Code</code>,  <code>Response Time</code>, <code>Application ID</code>, <code>Application Index</code>, and <code>Extra Headers</code>. 
+* The following are optional fields: <code>Status Code</code>,  <code>Response Time</code>, <code>Application ID</code>, <code>Application Index</code>, and <code>Extra Headers</code>.
 
-If the access log lacks a <code>Status Code</code>,  <code>Response Time</code>, <code>Application ID</code>, or <code>Application Index</code>, the corresponding field shows `-`. 
+* If the access log lacks a <code>Status Code</code>,  <code>Response Time</code>, <code>Application ID</code>, or <code>Application Index</code>, the corresponding field shows `-`.
+
+* `Response Time` is the total time it takes for the request to go through the GoRouter to the app and for the response to travel back through the GoRouter. This includes the time the request spends traversing the network to the app and back again to the GoRouter. It also includes the time the app spends forming a response.
+
+* `GoRouter Time` is the total time it takes for the request to go through the GoRouter initially plus the time it takes for the response to travel back through the GoRouter. This does not include the time the request spends traversing the network to the app. This also does not include the time the app spends forming a response. 
+
 
 <p class="note"><strong>Note</strong>: Access logs are also redirected to syslog.</p>


### PR DESCRIPTION
- we added a new field on the access logs: gorouter_time
- we wanted to be clear about the differences between response time and gorouter time, so we added definitions

[#170285659](https://www.pivotaltracker.com/story/show/170285659)