### PR TITLE
Update org user role for v3/v2

### DIFF
--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -59,7 +59,7 @@ information.
 <%= vars.billing_manager_role %>
 <%= vars.billing_manager_role_note %>
 
-* **Org Users**: Read-only access to the list of other org users and their roles. When an Org Manager gives a person an Org or Space role, that person automatically receives Org User status in that org.
+* **Org Users**: Read-only access to the list of other org users and their roles. In the v2 Cloud Controller API, when an Org Manager gives a person an Org or Space role, that person automatically receives Org User status in that org. This is no longer the case in the v3 Cloud Controller API.
 
 * **Space Managers**: Administer a space within an org.
 


### PR DESCRIPTION
Hey docs friends!

In v3 org user is no longer auto assigned when an org manager grants any org or space role.

This change came from the following github issue in CCNG: https://github.com/cloudfoundry/cloud_controller_ng/issues/2130

Thanks,
Jenna and @sethboyles 