### PR TITLE
Clarify on http routing

### DIFF
--- a/http-routing.html.md.erb
+++ b/http-routing.html.md.erb
@@ -12,7 +12,8 @@ For more information, see the [Routing](./architecture/index.html#routing) secti
 
 #### <a id="header-size-limit"></a> Header Size Limit
 
-The Gorouter has a limit of 1&nbsp;MB for HTTP Headers.
+The Gorouter has a limit of 1&nbsp;MB for HTTP Headers. But in practice, the actual limit is likely lowered by the backend app container,
+subject to the specific language/framework and configuration. For example, the Tomcat container has a default 8kB header size.
 
 #### <a id="X-Forwarded-Proto"></a> X-Forwarded-Proto
 
@@ -244,7 +245,7 @@ The Gorouter supports keep-alive connections from clients and does not close the
 
 If keep-alive connections are disabled, the Gorouter closes the TCP connection with an app instance or system component after receiving an HTTP response.
 
-If keep-alive connections are enabled, the Gorouter maintains established TCP connections to back ends. The Gorouter supports up to 10 idle connections to each back end:
+If keep-alive connections are enabled, the Gorouter maintains established TCP connections to back ends. The Gorouter supports up to 100 idle connections to each back end:
 
 * If an idle connection exists for a given back end, the Gorouter reuses it to route subsequent requests.
 * If no idle connection exists for this back end, the Gorouter creates a new connection.


### PR DESCRIPTION
Clarify on HTTP header size, especially practical limits in a real deployment. Also corrected the error of gorouter keep-alive backend connection limits.