### PR TITLE
SPACE configuration for cf bind-security-group

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -197,7 +197,7 @@ To bind an ASG to a space-scoped running ASG set:
 1. Run:
 
     ```
-    cf bind-security-group ASG ORG SPACE
+    cf bind-security-group ASG ORG --space SPACE
     ```
     Where:
     * `ASG` is the name of your ASG.
@@ -209,7 +209,7 @@ To bind an ASG to a space-scoped staging ASG set:
 1. Run:
 
     ```
-    cf bind-security-group ASG ORG SPACE --lifecycle staging
+    cf bind-security-group ASG ORG --space SPACE --lifecycle staging
     ```
     Where:
     * `ASG` is the name of your ASG.


### PR DESCRIPTION
Since cf cli v7, the usage of `cf bind-security-group` has been changed as below - i.e., we need to specify SPACE with `--space`
- cf bind-security-group SECURITY_GROUP ORG [--lifecycle (running | staging)] [--space SPACE]

Based on this change, the ASG docs for TAS 2.12 should be change because it's requred to use cf cli v8.