### PR TITLE
add non-admin ASG commands to role permissions table

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -406,6 +406,34 @@
     <td></td>
   </tr>
   <tr>
+    <td>Manage Application Security Groups for all spaces in an org</td>
+    <td>Yes</td>
+    <td></td>
+    <td></td>
+    <td>Yes</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Manage Application Security Groups for an individual space</td>
+    <td>Yes</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>Yes</td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
     <td>Create, update, and delete an isolation segment</td>
     <td>Yes</td>
     <td></td>


### PR DESCRIPTION
Non-admins have the ability to bind and unbind ASGs for the orgs and spaces that they can manage. This change adds additional rows in the table to make that explicit.