### PR TITLE
Add log rate limiting docs

### DIFF
--- a/_oss_roles_table.html.md.erb
+++ b/_oss_roles_table.html.md.erb
@@ -378,7 +378,7 @@
     <td></td>
   </tr>
   <tr>
-    <td>Associate routes<sup><strong>4</strong></sup>, instance counts, memory allocation, and disk limit of apps</td>
+    <td>Associate routes<sup><strong>4</strong></sup>, modify resource allocation of apps</td>
     <td>Yes</td>
     <td></td>
     <td></td>

--- a/_suspended_org_roles_table.html.md.erb
+++ b/_suspended_org_roles_table.html.md.erb
@@ -255,7 +255,7 @@
         <td></td>
         <td></td>
     </tr><tr>
-        <td>Associate routes<sup>&dagger;</sup>, instance counts, memory allocation, and disk limit of apps</td>
+        <td>Associate routes<sup>&dagger;</sup>, modify resource allocation of apps</td>
         <td>Yes</td>
         <td></td>
         <td></td>

--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -37,6 +37,7 @@ Org managers can set quotas on the following for a space:
 * Number of reserved route ports
 * Memory used across the space
 * Memory used by a single app instance
+* Log volume per second used across the space
 
 
 ## <a id='roles'></a> User Roles


### PR DESCRIPTION
- With the addition of log rate limiting we decided to no longer enumerate all of the resource types that can be allocated.
- Also mention log rate as a resource that can be constrained.

@ctlong