### PR TITLE
Add Healthchecker documentation

### DIFF
--- a/_oss_healthchecker_documentation.md.erb
+++ b/_oss_healthchecker_documentation.md.erb
@@ -1,0 +1,10 @@
+#### <a id="healthchecker_documentation"></a> HealthChecker usage by monit
+
+This componnent utilizes the <a href="https://github.com/cloudfoundry/healthchecker-release">Healthchecker-release</a> to perform it's monit healthchecks.  The healthchecker add TCP and HTTP healtchecks to extend standard monit service checks.  Since the version of monit included in BOSH does not support specific tcp/http health checks, we designed this utility to perform health checking and restart processes if they become unreachable.
+
+##### How it Works
+Healthchecker is added to a bosh release as a monit process under the Job that is to be monitored. It is configured to perform a healthcheck against the main process in the Job. If healthchecker detects a failure, it will panic and exit. The healthchecker supplementary script restarts the main monit process, allowing up to ten failures in a row. After 10 consecutive failures, it gives up, since restarting the process is either in a poor state, or the healthchecker is misconfigured and should not be causing process downtime.
+
+This component typically requires no additional configuration from platform operators.
+
+

--- a/architecture/garden.html.md.erb
+++ b/architecture/garden.html.md.erb
@@ -40,6 +40,7 @@ Garden-runC has the following features:
 
 For more information, see the [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) repository on GitHub.
 
+<%= partial '../oss_healthchecker_documentation' %>
 
 ## <a id='garden-rootfs'></a> Garden RootFS (GrootFS)
 

--- a/cf-routing-architecture.html.md.erb
+++ b/cf-routing-architecture.html.md.erb
@@ -29,6 +29,7 @@ The following summarizes the roles and responsibilities of various components de
 | Routing API | Receives routing configuration from route emitter and other internal clients, and provides routing configuration for TCP router. |
 | Routing database | Saves some routing data from Routing API. If the Gorouter misses a message about an unmapped route from NATS, it will not get it again, so TCP router and Routing API can consult routing database for current state of routes. |
 | TCP router | Routes TCP traffic coming into <%= vars.app_runtime_abbr %> to the appropriate component. Receives route updates through the routing API. |
+| HealthChecker | An executable designed to perform TCP/HTTP based health checks of processes managed by monit in BOSH releases. Since the version of monit included in BOSH does not support specific tcp/http health checks, we designed this utility to perform health checking and restart processes if they become unreachable. |
 
 ## <a id='ext-client'></a> External Client Request Flow
 

--- a/diego/diego-architecture.html.md.erb
+++ b/diego/diego-architecture.html.md.erb
@@ -108,6 +108,11 @@ The following table describes the jobs that are part of the <%= vars.app_runtime
 		<li>Periodically emits the entire routing table to the <%= vars.app_runtime_abbr %> Gorouter.</li></ul></td>
 	</tr>
 	<tr>
+		<td><strong>Job:</strong><br> diego-healthchecker<br>
+		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> diego-cell<% else %> <%= vars.diego_vm_3 %> <% end %></td>
+		<td><ul><li>An executable designed to perform TCP/HTTP based health checks of processes managed by monit in BOSH releases.</li><li>Since the version of monit included in BOSH does not support specific tcp/http health checks, we designed this utility to perform health checking and restart processes if they become unreachable.</li></ul></td>
+	</tr>
+	<tr>
 		<td><strong>Job:</strong><br> ssh_proxy<br>
 		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> scheduler<% else %> <%= vars.diego_vm_1 %> <% end %></td>
 		<td><ul><li>Brokers connections between SSH clients and SSH servers</li><li>Runs inside instance containers and authorizes access to app instances based on Cloud Controller roles</li></ul></td>


### PR DESCRIPTION
Signed-off-by: Marc Paquette <mpaquette@vmware.com>

The healthchecker-release has now been externalized to it's own release.  This documentation has been updated to outline how healthchecker's behavior is different than the standard monit health check.