### PR TITLE
Update documentation to reflect the changes within Garden-runc-release v1.43.0

### DIFF
--- a/_oss_healthchecker_documentation.md.erb
+++ b/_oss_healthchecker_documentation.md.erb
@@ -1,7 +1,0 @@
-#### <a id="healthchecker_documentation"></a> HealthChecker usage by monit
-
-This component uses the <a href="https://github.com/cloudfoundry/healthchecker-release">Healthchecker-release</a> to perform the monit health checks. It adds TCP and HTTP health checks to extend standard monit service checks. Because the version of monit included in BOSH does not support specific TCP or HTTP health checks, this utility performs health checking and restart processing when they become unreachable.
-
-Healthchecker is added to a BOSH release as a monit process under the Job to be monitored. It is configured to perform a health check against the main process in the Job. If Healthchecker detects a failure, it exits. The Healthchecker supplementary script restarts the main monit process, allowing up to ten failures in a row. After ten consecutive failures, it stops restarting the Job because the process is either in a poor state, or the health checker is misconfigured and is causing process downtime.
-
-This component typically requires no additional configuration by platform operators.

--- a/architecture/garden.html.md.erb
+++ b/architecture/garden.html.md.erb
@@ -46,8 +46,6 @@ Garden-runC has the following features:
 
 For more information, see the [Garden-runC](https://github.com/cloudfoundry/garden-runc-release) repository on GitHub.
 
-<%= partial '../oss_healthchecker_documentation' %>
-
 ## <a id='garden-rootfs'></a> Garden RootFS plug-in
 
 Garden manages container file systems through a plug-in interface. <%= vars.app_runtime_abbr %> uses the Garden RootFS (GrootFS) plug-in for this task.


### PR DESCRIPTION
Updating the documentation to reflect the most up to date information for garden-runc releases.

We removed the healthchecker in [Garden-runc-release v1.43.0](https://github.com/cloudfoundry/garden-runc-release/releases/tag/v1.43.0)