### PR TITLE
ASG destinations can now be a list in OS CF

### DIFF
--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -97,7 +97,12 @@ ASG rules are specified as a JSON array of ASG objects. An ASG object has the fo
 | Attribute | Description | Notes |
 | --------- | ----------- | ----- |
 | `protocol` | `tcp`, `udp`, `icmp`, or `all` | Required |
+<% if vars.platform_code == 'CF' %>
+| `destination` | A comma deliminated list of single IP addresses, IP address ranges like `192.0.2.0-192.0.2.50`, or CIDR blocks that can receive traffic | Destination lists became available in capi-release 1.180.0.  |
+<% end %>
+<% if vars.platform_code == 'PCF' %>
 | `destination` | A single IP address, an IP address range like `192.0.2.0-192.0.2.50`, or a CIDR block that can receive traffic |  |
+<% end %>
 | `ports` | A single port, multiple comma-separated ports, or a single range of ports that can receive traffic. Examples: `443`, `80,8080,8081`, `8080-8081` | Only possible if `protocol` is `tcp` or `udp`. |
 | `code` | ICMP code | Required when `protocol` is `icmp`. A value of `-1` allows all codes. |
 | `type` | ICMP | Required when `protocol` is `icmp`. A value of `-1` allows all types.
@@ -159,7 +164,12 @@ following example, which allows ICMP traffic of code `1` and type `0` to all des
       },
       {
         "protocol": "tcp",
+<% if vars.platform_code == 'CF' %>
+        "destination": "10.0.11.0/24,8.8.8.8",
+<% end %>
+<% if vars.platform_code == 'PCF' %>
         "destination": "10.0.11.0/24",
+<% end %>
         "ports": "80,443",
         "log": true,
         "description": "Allow http and https traffic to ZoneA"

--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -98,7 +98,7 @@ ASG rules are specified as a JSON array of ASG objects. An ASG object has the fo
 | --------- | ----------- | ----- |
 | `protocol` | `tcp`, `udp`, `icmp`, or `all` | Required |
 <% if vars.platform_code == 'CF' %>
-| `destination` | A comma deliminated list of single IP addresses, IP address ranges like `192.0.2.0-192.0.2.50`, or CIDR blocks that can receive traffic | Destination lists became available in capi-release 1.180.0.  |
+| `destination` | A comma deliminated list of single IP addresses, IP address ranges like `192.0.2.0-192.0.2.50`, or CIDR blocks that can receive traffic | Destination lists became available in capi-release 1.180.0 and can be enabled by setting the `cc.security_groups.enable_comma_delimited_destinations` bosh property to true.  |
 <% end %>
 <% if vars.platform_code == 'PCF' %>
 | `destination` | A single IP address, an IP address range like `192.0.2.0-192.0.2.50`, or a CIDR block that can receive traffic |  |


### PR DESCRIPTION
All new content is behind a if block and shown in OSS docs only. Once this feature is in TAS I will update the TAS docs.