### PR TITLE
Add note about X-Cf-App-Instance incompatibility with route services

### DIFF
--- a/http-routing.html.md.erb
+++ b/http-routing.html.md.erb
@@ -153,6 +153,8 @@ To make an HTTP request to a specific app instance:
 	</tbody>
 	</table>
 
+Note: The `X-Cf-App-Instance` header is not effective for applications which have a route service configured.
+
 ### <a id='forward-client-cert'></a> Forwarding client certificate to apps
 
 Apps that require mutual TLS (mTLS) need metadata from client certificates to authorize requests. <%= vars.app_runtime_abbr %> supports this use case without


### PR DESCRIPTION
We found out that so-called surgical requests, where X-Cf-App-Instance is used to call a specific instance, are not supported in the route service scenario. The header is always dropped even before sending the first request to the route service, and the header is not considered when making the actual call to the target application.

This behavior has been implemented in 2016, see this [Git commit](https://github.com/cloudfoundry/gorouter/commit/c5d74c01d117952947a2a64880d4a8179154082c).

This is the related story: https://pivotaltracker.com/n/projects/1358110/stories/129122189