### PR TITLE
default overlay network is now an array of CIDRs

### DIFF
--- a/understand-cf-networking.html.md.erb
+++ b/understand-cf-networking.html.md.erb
@@ -106,10 +106,11 @@ Container-to-container networking uses an overlay network to manage communicatio
 
 Overlay networks are not externally routable, and traffic sent between containers does not exit the overlay. You can use the same overlay network range for different <%= vars.app_runtime_abbr %> deployments in your environment.
 
-The overlay network range defaults to `10.255.0.0/16`. You can modify the default to any [RFC&nbsp;1918](https://tools.ietf.org/html/rfc1918) range that meets the following requirements:
+The overlay network range defaults to `["10.255.0.0/16"]`. You can modify the default to include any [RFC&nbsp;1918](https://tools.ietf.org/html/rfc1918) range that meets the following requirements:
 
 * The range is not used by services that app containers access.
 * The range is not used by the underlying <%= vars.app_runtime_abbr %> infrastructure.
+* The ranges do not overlap with each other.
 
 All Diego Cells in your <%= vars.app_runtime_abbr %> deployment share this overlay network. By default, each Diego Cell is allocated a /24 range that supports 254 containers per Diego Cell, one container for each of the usable IP addresses, `.1` through `.254`. To modify the number of Diego Cells your overlay network supports, see [Overlay Network](../devguide/deploy-apps/cf-networking.html#overlay) in _Configuring Container-to-Container Networking_.
 

--- a/understand-cf-networking.html.md.erb
+++ b/understand-cf-networking.html.md.erb
@@ -121,6 +121,12 @@ The overlay network IP address range must not conflict with any other IP address
 conflict exists, Diego Cells cannot reach any endpoint that has a conflicting IP address.
 </p>
 
+<p class="note caution">
+Updating the overlay network will cause container-to-container networking
+downtime during the deploy while the network update is rolling out across Diego
+Cells.
+</p>
+
 Traffic to app containers from the Gorouter or from app containers to external services uses
 Diego Cell IP addresses and NAT, not the overlay network.
 


### PR DESCRIPTION
Draft because this work is not merged in yet. Longer description of this work is here: https://github.com/cloudfoundry/silk-release/pull/148

This change should only be for....
* open source
* TPCF 10.2 (or whatever version is next)

This change is NOT for...
* TPCF 10
* TAS 6
* TAS 4