### PR TITLE
Remove platform-conditional ERB blocks, keep OSS content [ai-assisted]

### DIFF
--- a/apps-index.html.md.erb
+++ b/apps-index.html.md.erb
@@ -4,11 +4,6 @@ owner: Docs
 ---
 
 <%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("How", vars.app_runtime_abbr, "Manages Apps") %>
-
-<% end %>
 
 The following topics provide information about how <%= vars.app_runtime_first %> manages apps:
 

--- a/architecture/cloud-controller.html.md.erb
+++ b/architecture/cloud-controller.html.md.erb
@@ -8,10 +8,7 @@ system.
 Cloud Controller maintains a database with tables for orgs, spaces,
 services, user roles, and more.
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'cc_communications' %>
-<% else %>
-<% end %>
 
 ##<a id='auction'></a>Diego Auction
 
@@ -20,11 +17,7 @@ processes over the [Diego Cells](index.html#diego-cell) in a <%= vars.app_runtim
 
 ##<a id='database'></a>Database (CC_DB)
 
-<% if vars.platform_code == 'CF' %>
 The Cloud Controller database has been tested with Postgres and MySQL.
-<% else %>
-The Cloud Controller database has been tested with MySQL.
-<% end %>
 
 ##<a id='blob-store'></a>Blobstore
 
@@ -33,8 +26,6 @@ To stage and run apps, <%= vars.app_runtime_abbr %> manages and stores app sourc
 Please see [Cloud Controller blobstore](../cc-blobstore.html) for information.
 
 ##<a id='testing'></a>Testing
-
-<% if vars.platform_code == 'CF' %>
 
 By default `rspec` runs a test suite with the SQLite in-memory database.
 Specify a connection string using the `DB_CONNECTION` environment variable to
@@ -46,17 +37,5 @@ test against Postgres and MySQL. For example:
 ~~~
 
 Travis currently runs two build jobs against Postgres and MySQL.
-
-<% else %>
-
-By default `rspec` runs a test suite with the SQLite in-memory database.
-Specify a connection string using the `DB_CONNECTION` environment variable to
-test against MySQL. For example:
-
-~~~
-    DB_CONNECTION="mysql2://root:password@localhost:3306/ccng" rspec
-~~~
-
-<% end %>
 
 <%= vars.cloud_controller_logging %>

--- a/architecture/index.html.md.erb
+++ b/architecture/index.html.md.erb
@@ -3,9 +3,6 @@ title: Runtime components
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-<% set_title(vars.app_runtime_abbr, "Components") %>
-<% end %>
 
 This topic tells you about the <%= vars.app_runtime_first %> runtime components.
 
@@ -98,14 +95,6 @@ The route emitter component uses the NATS protocol to broadcast the latest routi
 
 The Loggregator (log aggregator) system streams application logs to developers.
 
-<% if vars.platform_code == "CF" %>
-
 For more information about the Loggregator, see <a href="https://docs.cloudfoundry.org/loggregator/architecture.html">Loggregator Architecture</a>.
 
 <%= partial 'old_collector' %>
-
-<% else %>
-
-For more information about the Loggregator architecture, see <a href="../../loggregator/architecture.html">Loggregator Architecture</a>.
-
-<% end %>

--- a/asg.html.md.erb
+++ b/asg.html.md.erb
@@ -46,17 +46,9 @@ for the apps that allow those service subnets, while denying access to any VM ho
 
 For examples of typical ASGs, see [Typical ASGs](#typical-groups).
 
-<% if vars.platform_code == 'CF' %>
 ### <a id='default-asg'></a> Default ASGs
 
 <%= partial "default_asg_oss" %>
-<% end %>
-
-<% if vars.platform_code == "PCF" %>
-### <a id='default-asg'></a> Default ASGs
-
-<%= partial "/core/default_asg" %>
-<% end %>
 
 ### <a id="asg-sets"></a> ASG sets
 
@@ -94,20 +86,13 @@ ASG rules are specified as a JSON array of ASG objects. An ASG object has the fo
 | Attribute | Description | Notes |
 | --------- | ----------- | ----- |
 | `protocol` | `tcp`, `udp`, `icmp`, or `all` | Required |
-<% if vars.platform_code == 'CF' %>
 | `destination` | A comma deliminated list of single IP addresses, IP address ranges like `192.0.2.0-192.0.2.50`, or CIDR blocks that can receive traffic | Destination lists became available in capi-release 1.180.0 and can be enabled by setting the `cc.security_groups.enable_comma_delimited_destinations` bosh property to true.  |
-<% end %>
-<% if vars.platform_code == 'PCF' %>
-| `destination` | A single IP address, an IP address range like `192.0.2.0-192.0.2.50`, or a CIDR block that can receive traffic |  |
-<% end %>
 | `ports` | A single port, multiple comma-separated ports, or a single range of ports that can receive traffic. Examples: `443`, `80,8080,8081`, `8080-8081` | Only possible if `protocol` is `tcp` or `udp`. |
 | `code` | ICMP code | Required when `protocol` is `icmp`. A value of `-1` allows all codes. |
 | `type` | ICMP | Required when `protocol` is `icmp`. A value of `-1` allows all types.
 | `log` | Set to `true` to enable logging. For more information about how to configure system logs to be sent to a syslog drain, see [Using Log Management Services](../devguide/services/log-management.html). | Logging is only supported with protocol type `tcp`. |
 | `description` | An optional field for operators managing ASG rules |  |
 
-
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 
 ## <a id="process"></a> Managing ASGs
 
@@ -161,12 +146,7 @@ following example, which allows ICMP traffic of code `1` and type `0` to all des
       },
       {
         "protocol": "tcp",
-<% if vars.platform_code == 'CF' %>
         "destination": "10.0.11.0/24,8.8.8.8",
-<% end %>
-<% if vars.platform_code == 'PCF' %>
-        "destination": "10.0.11.0/24",
-<% end %>
         "ports": "80,443",
         "log": true,
         "description": "Allow http and https traffic to ZoneA"
@@ -462,6 +442,3 @@ The ASG Creator is a command line tool that you can use to create JSON rules fil
 In turn, the JSON file is the input for the `cf create-security-group` command that creates an ASG.
 
 To download the latest release of the ASG Creator, see the [Cloud Foundry Incubator](https://github.com/cloudfoundry-incubator/asg-creator/releases/latest) repository on GitHub.
-
-
-<% end %>

--- a/cc-blobstore.html.md.erb
+++ b/cc-blobstore.html.md.erb
@@ -47,10 +47,7 @@ This topic references staging and treats all blobstores as generic object stores
 
 For more information about staging, see [How Apps Are Staged](../concepts/how-applications-are-staged.html).
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
-
 For more information about how specific third-party blobstores can be configured, see <%= vars.blobstore_link %>.
-<% end %>
 
 ## <a id='stage-blobstore'></a> Staging using the blobstore
 

--- a/cf-routing-architecture.html.md.erb
+++ b/cf-routing-architecture.html.md.erb
@@ -4,11 +4,6 @@ owner: CF for VMs Networking
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title(vars.app_runtime_abbr, "Routing Architecture") %>
-
-<% end %>
 
 This topic tells you about the routing architecture and flow in <%= vars.app_runtime_first %>.
 

--- a/container-security.html.md.erb
+++ b/container-security.html.md.erb
@@ -54,7 +54,6 @@ The calculation of the CPU usage based on the percentage of the total CPU power 
 process_cpu_share_percent = cpu.shares / sum_cpu_shares * 100
 ```
 
-<% if vars.platform_code == 'CF' %>
 In <%= vars.app_runtime_abbr %>, cgroup shares range from 10 to 1024. The actual number of shares a cgroup gets can be read from the `cpu.shares` file of the cgroup configurations pseudo-file-system available in the container at `/sys/fs/cgroup/cpu`. The number of shares given to an apps cgroup depends on the amount of memory the app declares to need in the manifest.
 
 #### CPU Shares Algorithm 1
@@ -119,23 +118,7 @@ In this case, the following algorithm is used to determine the number of CPU sha
 process_cpu.shares = app_memory_in_mb + containers.proxy.additional_memory_allocation_mb
 ```
 
-<% else %>
-The actual number of shares a cgroup gets can be read from the `cpu.shares` file of the cgroup configurations pseudo-file-system available in the container at `/sys/fs/cgroup/cpu`.
-The number of shares given to an apps cgroup depends on the amount of memory the app declares to need in the manifest. 
-<%= vars.app_runtime_abbr %> scales the number of allocated shares linearly with the amount of memory.
-
-The following algorithm is used to determine the number of CPU shares for an app:
-```
-process_cpu.shares = app_memory_in_mb + 32
-```
-
-The extra `32` in the algorithm is to account for the extra memory required for the envoy sidecar proxy.
-
-<% end %>
-
-<% if vars.platform_code == 'CF' %>
 #### CPU Share Interaction
-<% end %>
 
 The next example helps to illustrate this better. Consider three processes: P1, P2 and P3, which are assigned `cpu.shares` of 5, 20 and 30, respectively.
 
@@ -218,9 +201,7 @@ Garden has the following container types:
 
 Currently, <%= vars.app_runtime_abbr %> runs all app instances and staging tasks in unprivileged containers by default. This measure increases security by eliminating the threat of root escalation inside the container.
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'config_manifest' %>
-<% end %>
 
 ### <a id='hardening'></a> Hardening
 

--- a/diego/diego-architecture.html.md.erb
+++ b/diego/diego-architecture.html.md.erb
@@ -107,44 +107,44 @@ The following table describes the jobs that are part of the <%= vars.app_runtime
 <tbody>
 	<tr>
 		<td><strong>Job:</strong><br> auctioneer<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> scheduler <% else %> <%= vars.diego_vm_1 %> <% end %></td>
+		<strong>VM:</strong><br>  scheduler </td>
 		<td><ul><li>Distributes work through auction to Cell Reps over SSL/TLS. For more information, see <a href="diego-auction.html">How the Diego Auction Allocates Jobs</a>.</li><li>Maintains a lock in Locket to ensure only one auctioneer handles auctions at a time.</li></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> bbs<br>
-		<strong>VM:<br></strong> <% if vars.platform_code == 'CF' %> diego-api <% else %> <%= vars.diego_vm_2 %> <% end %></td>
+		<strong>VM:<br></strong>  diego-api </td>
 		<td><ul><li>Maintains a real-time representation of the state of the Diego cluster, including desired LRPs, running LRPs, and in-flight Tasks.</li><li>Provides an RPC-style API over HTTP to Diego Core components for external clients as well as internal clients, including the SSH Proxy and Route Emitter.</li><li>Ensures consistency and fault tolerance for Tasks and LRPs by comparing desired state with actual state.</li>
 		<li>Keeps <code>DesiredLRP</code> and <code>ActualLRP</code> counts synchronized. If the <code>DesiredLRP</code> count exceeds the <code>ActualLRP</code> count, requests a start auction from the Auctioneer. If the <code>ActualLRP</code> count exceeds the <code>DesiredLRP</code> count, sends a stop message to the Rep on the Diego Cell hosting an instance</li></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> file_server<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> api <% else %> <%= vars.diego_vm_1 %> <% end %></td>
+		<strong>VM:</strong><br>  api </td>
 		<td><ul><li>Serves static assets that can include general-purpose App Lifecycle binaries</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> locket<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> diego-api<% else %> <%= vars.diego_vm_2 %> <% end %></td>
+		<strong>VM:</strong><br>  diego-api</td>
 		<td><ul><li>Provides a consistent key-value store for maintenance of distributed locks and component presence</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> rep<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> diego-cell<% else %> <%= vars.diego_vm_3 %> <% end %></td>
+		<strong>VM:</strong><br>  diego-cell</td>
 		<td><ul><li>Represents a Diego Cell in Diego Auctions for Tasks and LRPs</li><li>Runs Tasks and LRPs by creating a container and then running actions in it</li><li>Periodically ensures its set of Tasks and ActualLRPs in the BBS is in sync with the containers actually present on the Diego Cell</li><li>Manages container allocations against resource constraints on the Diego Cell, such as memory and disk space</li><li>Streams stdout and stderr from container processes to the metron-agent running on the Diego Cell, which in turn forwards to the Loggregator system</li><li>Periodically collects container metrics and emits them to Loggregator</li><li>Mediates all communication between the Diego Cell and the BBS</li><li>Maintains a presence record for the Diego Cell in Locket</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> route_emitter<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> diego-cell<% else %> <%= vars.diego_vm_3 %> <% end %></td>
+		<strong>VM:</strong><br>  diego-cell</td>
 		<td><ul><li>Monitors <code>DesiredLRP</code> and <code>ActualLRP</code> states, emitting route registration and unregistration messages to Gorouter when it detects changes.</li>
 		<li>Periodically emits the entire routing table to the <%= vars.app_runtime_abbr %> Gorouter.</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> diego-healthchecker<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> diego-cell<% else %> <%= vars.diego_vm_3 %> <% end %></td>
+		<strong>VM:</strong><br>  diego-cell</td>
 		<td><ul><li>An executable designed to perform TCP/HTTP based health checks of processes managed by monit in BOSH releases.</li><li>Because the version of monit included in BOSH does not support specific tcp/http health checks, we designed this utility to perform health checking and restart processes if they become unreachable.</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> ssh_proxy<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> scheduler<% else %> <%= vars.diego_vm_1 %> <% end %></td>
+		<strong>VM:</strong><br>  scheduler</td>
 		<td><ul><li>Brokers connections between SSH clients and SSH servers</li><li>Runs inside instance containers and authorizes access to app instances based on Cloud Controller roles</li></ul></td>
 	</tr>
 </tbody>
@@ -202,12 +202,12 @@ The following table describes jobs that interact closely with Diego but are not 
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> cc_uploader<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> api <% else %> <%= vars.diego_vm_1 %> <% end %></td>
+		<strong>VM:</strong><br>  api </td>
 		<td><ul><li>Mediates uploads from the Executor to the Cloud Controller</li><li>Translates simple HTTP POST requests from the Executor into complex multipart-form uploads for the Cloud Controller</li></ul></td>
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> database<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> pxc-mysql <% else %> <%= vars.mysql_vm %> <% end %></td>
+		<strong>VM:</strong><br>  pxc-mysql </td>
 		<td><ul><li>Provides a consistent key-value data store to Diego</li></ul></td>
 	</tr>
 	<tr>
@@ -217,7 +217,7 @@ The following table describes jobs that interact closely with Diego but are not 
 	</tr>
 	<tr>
 		<td><strong>Job:</strong><br> cloud_controller_clock<br>
-		<strong>VM:</strong><br> <% if vars.platform_code == 'CF' %> scheduler<% else %> <%= vars.clock_vm %> <% end %></td>
+		<strong>VM:</strong><br>  scheduler</td>
 		<td><ul><li>Runs a Diego sync process to ensure desired app data in Diego is in sync with the Cloud Controller.</li></ul></td>
 	</tr>
 	</tbody>

--- a/glossary.html.md.erb
+++ b/glossary.html.md.erb
@@ -3,11 +3,6 @@ title: Cloud Foundry component glossary
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title(vars.app_runtime_abbr, "Component Glossary") %>
-
-<% end %>
 
 This topic tells you about <%= vars.app_runtime_first %> terms and definitions.
 

--- a/high-availability.html.md.erb
+++ b/high-availability.html.md.erb
@@ -4,11 +4,6 @@ owner: Release Integration
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("High Availability in", vars.app_runtime_abbr) %>
-
-<% end %>
 
 This topic tells you about the components used to ensure high availability in <%= vars.app_runtime_first %>, vertical and horizontal scaling, and the infrastructure
 required to support scaling component VMs for high availability.
@@ -104,11 +99,7 @@ upgrades. For more information about using AZs, see [Availability Zones](#azs).
 
 <%= vars.scaling_ert %>
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'oss_scale_table' %>
-<% else %>
-<%= partial "/pcf/core/pcf_scale_table" %>
-<% end %>
 
 ## <a id='supporting-scaling'></a> Infrastructure for component scaling
 
@@ -117,10 +108,8 @@ deployment supports VM scaling.
 
 Learn about the infrastructure required to support scaling component VMs for high availability.
 
-<% if vars.platform_code == 'CF' %>
 <%= vars.max_in_flight_header %>
 <%= partial 'max_in_flight_text' %>
-<% end %>
 
 <%= vars.om_resurrector_header %>
 

--- a/http-routing.html.md.erb
+++ b/http-routing.html.md.erb
@@ -236,17 +236,9 @@ To require and validate client certificates on a <strong>per-domain</strong> bas
 
 The following sections describe supported deployment configurations.
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'oss_xfcc_loadbalancer' %>
-<% else %>
-<%= partial "/pcf/core/xfcc_loadbalancer" %>
-<% end %>
 
-<% if vars.platform_code == 'CF' %>
 <%= partial 'oss_xfcc_router' %>
-<% else %>
-<%= partial "/pcf/core/xfcc_router" %>
-<% end %>
 
 
 ## <a id='client-side-tls'></a> Client-Side TLS
@@ -273,7 +265,6 @@ For more information, see [Envoyproxy.io](https://www.envoyproxy.io/).
 
 ![alt-text"Gorouter connects to app process via Envoy proxy"](./images/envoy-proxy.png)
 
-<% if vars.platform_code == 'CF' %>
 This feature is allowed by default in `cf-deployment`, which configures the following properties:
 
 * `router.backends.enable_tls: true`
@@ -302,7 +293,6 @@ manifest properties:
 * `router.backends.private_key`
 
 The Gorouter presents the certificate if requested by the back end during the TLS handshake.
-<% end %>
 
 
 ## <a id='consistency'></a> Preventing mis-routes
@@ -323,7 +313,6 @@ If the Gorouter confirms that the app instance identifier in the certificate mat
 the HTTP request over the TLS session, and the Envoy proxy then forwards it to the app process. If the instance identifiers do not match, the Gorouter removes
 the app instance from its routing table and transparently retries another instance of the app.
 
-<% if vars.platform_code == 'CF' %>
 ### <a id='without-tls'></a> Without TLS to back ends enabled
 
 While it is possible to disallow TLS app identity verification, <%= vars.recommended_by %> does not recommend using this consistency mode.
@@ -338,20 +327,15 @@ Gorouter can validate app instance identity using TLS only when Diego Cells are 
 through the instance group that they belong to, the Gorouter can run in different consistency modes with Diego Cells in different instance groups. For
 example, the Gorouter can communicate over TLS and validate the Diego Cells in one isolation segment, while communicating with Diego Cells in another
 isolation segment over plain text and without validating instance identity.
-<% end %>
 
 Currently, only Linux cells support the Gorouter validating app instance identities using TLS by default. With Windows cells, the Gorouter connects to back
 ends without TLS, forwarding requests to Windows apps over plain text and pruning based on route TTL.
 
 ### <a id='app-valid-tls-config'></a> Configuring validation of app instance identity with TLS
 
-<% if vars.platform_code == 'CF' %>
 To enable this feature on Windows, use the
 [`enable-nginx-routing-integrity-windows2019.yml`](https://github.com/cloudfoundry/cf-deployment/blob/09456fce97dbeec8f374a789d0d3d0e1c166aa91/operations/experimental/enable-nginx-routing-integrity-windows2019.yml)
 experimental opsfile on GitHub.
-<% else %>
-<%= partial "/pcf/core/router_app_tls_pcf" %>
-<% end %>
 
 
 ## <a id='balancing-algorithm'></a> Router balancing algorithm
@@ -361,9 +345,7 @@ updated list of app instances for each route. Depending on which algorithm is se
 
 As a platform operator, you can configure the behavior by changing the value of `router.balancing_algorithm` manifest property.
 
-<% if vars.platform_code == 'CF' %>
 As an application developer, you can configure the load balancing algorithm by following the guide [Configuring per-route options](../devguide/custom-per-route-options.html) which describes how to specify load balancing algorithms scoped at the application level.
-<% end %>
 
 The possible options:
 
@@ -426,11 +408,7 @@ app instance. This allows apps to store session data specific to a user session.
 
 To support sticky sessions, configure your app to return a sticky session cookie in responses. The default value for this field is `JSESSIONID`. You can
 configure the cookie names that the routing tier uses for sticky sessions.
-<% if vars.platform_code == 'CF' %>
 To configure the names of the cookies, edit the `router.sticky_session_cookie_names` config key in your manifest.
-<% else %>
-<%= vars.tas_networking %>
-<% end %>
 
 If an app returns a sticky session cookie to a client request, the <%= vars.app_runtime_abbr %> routing tier generates a unique `VCAP_ID` for the app instance
 based on its GUID with the same expiry, sameSite, and secure attributes as `JSESSIONID`. For example:
@@ -470,10 +448,7 @@ each back end:
 
 * If no idle connection exists for this back end, the Gorouter creates a new connection.
 
-<% if vars.platform_code == 'CF' %>
 <%= vars.keepalive %>
-<% else %>
-<% end %>
 
 
 ## <a id='retry'></a> Transparent retries
@@ -509,5 +484,5 @@ breaks. The following table describes how the Gorouter behaves if it cannot esta
 </tbody>
 </table>
 
-In all cases, if the app still does not respond to the request, the Gorouter returns a `502` error. <% if vars.platform_code != "OFFLINE" %>For more
-information, see [Troubleshooting Router Error Responses](../adminguide/troubleshooting-router-error-responses.html).<% end %>
+In all cases, if the app still does not respond to the request, the Gorouter returns a `502` error. For more
+information, see [Troubleshooting Router Error Responses](../adminguide/troubleshooting-router-error-responses.html).

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -3,19 +3,9 @@ title: Cloud Foundry concepts
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
 
-<% set_title(vars.app_runtime_abbr, "Concepts") %>
-
-<% end %>
-
-<% if vars.platform_code == 'CF' %>
 <%= vars.app_runtime_first %> is an open-source cloud app platform, providing a choice of clouds, developer
 frameworks, and app services. Cloud Foundry makes it faster and easier to build, test, deploy, and scale apps. It is an open-source project and is available through a variety of private cloud distributions and public cloud instances. For more information, see [Cloud Foundry](https://github.com/cloudfoundry) on GitHub.
-<% else %>
-<%= vars.app_runtime_first %> is based on Cloud Foundry, which is an open-source cloud app platform, providing a choice of clouds, developer frameworks, and app
-services. <%= vars.app_runtime_abbr %> makes it faster and easier to build, test, deploy, and scale apps. It is an open-source project and is available through a variety of private cloud distributions and public cloud instances. For more information, see [Cloud Foundry](https://github.com/cloudfoundry) on GitHub.
-<% end %>
 
 This documentation presents an overview of
 how <%= vars.app_runtime_abbr %> works and a discussion of key concepts.
@@ -30,8 +20,4 @@ To learn more about <%= vars.app_runtime_abbr %> fundamentals, see the following
 
 * [How <%= vars.app_runtime_abbr %> Manages Apps](apps-index.html)
 
-<% if vars.platform_code == 'CF' %>
 * [Runtime Components](architecture/index.html)
-<% else %>
-* [<%= vars.app_runtime_abbr %> Components](architecture/index.html)
-<% end %>

--- a/maintaining-high-availability.html.md.erb
+++ b/maintaining-high-availability.html.md.erb
@@ -4,11 +4,6 @@ owner: Release Integration
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("How", vars.app_runtime_abbr, "Maintains High Availability") %>
-
-<% end %>
 
 <%= vars.app_runtime_first %> deployments make up several layers of high availability to keep your apps running during system failure.
 These layers include AZs, app health management, process monitoring, and VM resurrection.

--- a/orgs-and-spaces.html.md.erb
+++ b/orgs-and-spaces.html.md.erb
@@ -5,12 +5,6 @@ owner: CAPI
 
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Planning", vars.app_runtime_abbr, "orgs and spaces") %>
-
-<% end %>
-
 
 This topic tells you about the considerations for effectively planning foundations, orgs, and spaces. You can plan your orgs and spaces to make the best use of the
 authorization features in <%= vars.app_runtime_first %>.

--- a/overview.html.md.erb
+++ b/overview.html.md.erb
@@ -3,21 +3,8 @@ title: Cloud Foundry overview
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title(vars.app_runtime_abbr, "Overview") %>
-
-<% end %>
-
-<% if vars.platform_code == 'CF' %>
 
 This topic tells you about Cloud Foundry and how it works.
-
-<% else %>
-
-This topic tells you about <%= vars.app_runtime_first %> and how it works with <%= vars.ops_manager %>.
-
-<% end %>
 
 ## Introduction to Cloud Platforms
 
@@ -200,15 +187,7 @@ Component logs stream from rsyslog agents, and the cloud operator can configure 
 
 The Loggregator system aggregates the component metrics and app logs into a structured, usable form, the Firehose. You can use all of the output of the Firehose, or direct the output to specific uses, such as monitoring system internals, triggering alerts, or analyzing user behavior, by applying nozzles.
 
-<% if vars.platform_code == "CF" %>
-
 For more information, see <a href="https://docs.cloudfoundry.org/loggregator/architecture.html">Loggregator Architecture</a>.
-
-<% else %>
-
-For more information, see <a href="../loggregator/architecture.html">Loggregator Architecture</a>.
-
-<% end %>
 
 ### <a id='services'></a> Using services
 
@@ -226,11 +205,6 @@ For more information, see [Services](../services/index.html).
 
 <%= vars.concepts_sf_vs_full_header %>
 
-<% if vars.platform_code == 'PCF' %>
-<%= partial "/pcf/core/small_footprint_overview" %>
-<% else %>
-<% end %>
-
 <%= vars.small_footprint_comparison %>
 
 [//]: # (Comment: Below calls vars concept_product_* in book repository template_vars.yml.)
@@ -240,10 +214,6 @@ For more information, see [Services](../services/index.html).
 <%= vars.concepts_product_model_header %>
 
 <%# partials for vars.concepts_product_model_text %>
-<% if vars.platform_code == 'CF' %>
 <%= partial 'overview_model' %>
-<% else %>
-<%= partial "/pcf/core/pcf_overview_model" %>
-<% end %>
 
 <%= vars.concepts_product_model_image %>

--- a/roles.html.md.erb
+++ b/roles.html.md.erb
@@ -105,11 +105,8 @@ Each user role includes different permissions in a <%= vars.app_runtime_abbr %> 
 
 The following table describes the default permissions for various <%= vars.app_runtime_abbr %> roles in active orgs.
 
-<% if vars.platform_code == "CF" %>
-
 You can use feature flags to edit some of the default permissions in the following table.
 For more information, see <a href="../adminguide/listing-feature-flags.html">Using Feature Flags</a>.
-<% end %>
 
 
 <%= partial 'oss_roles_table' %>

--- a/security.html.md.erb
+++ b/security.html.md.erb
@@ -4,11 +4,6 @@ owner: Security
 ---
 
 <%# Reset page title based on product title %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title(vars.app_runtime_abbr, "Security") %>
-
-<% end %>
 
 This topic provides you with an overview of <%= vars.app_runtime_first %> security.
 For an overview of container security, see [Container Security](container-security.html).

--- a/understand-cf-networking.html.md.erb
+++ b/understand-cf-networking.html.md.erb
@@ -145,15 +145,11 @@ The policies you create specify a source app, destination app, protocol, and por
 
 Additionally, policies use and and track the GUIDs of the apps. The policies continue to work when apps redeploy, or if they crash and Diego places them in a new container. Pushing a brand new app requires a new policy, but not updates to an existing app because an app always retains its GUID.
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
-
 ## <a id='service-discovery'></a> App service discovery
 
 The <%= vars.app_runtime_abbr %> platform supports DNS-based service discovery that lets apps find each other's internal addresses. For example, a front end app instance can use the service discovery mechanism to establish communications with a back end app instance. To set up and use app service discovery, see [App service discovery](../devguide/deploy-apps/cf-networking.html#discovery) in _Configuring container-to-container networking_.
 
 Container-to-container app service discovery does not provide client-side load balancing or circuit-breaking, and it does not apply to `cf marketplace` services or require app binding. It just lets apps publish service endpoints to each other, unbrokered and unmediated.
-
-<% end %>
 
 
 ## <a id="alt-stack"></a> Alternative network stacks


### PR DESCRIPTION
This repo now serves only the OSS Cloud Foundry doc set, so the vars.platform_code == 'CF' / 'PCF' conditionals that used to branch content between the OSS and commercial builds no longer serve a purpose. Unwrap CF-branch content, drop PCF-only content, and remove the conditional tags across all 18 affected files.